### PR TITLE
shelob: changes to where internal things are served

### DIFF
--- a/mux/admin.go
+++ b/mux/admin.go
@@ -1,6 +1,7 @@
 package mux
 
 import (
+	"github.com/dbcdk/shelob/handlers"
 	"github.com/dbcdk/shelob/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
@@ -10,6 +11,8 @@ import (
 func CreateAdminMux(config *util.Config) *http.ServeMux {
 	mux := http.NewServeMux()
 
+	mux.Handle("/", http.HandlerFunc(handlers.CreateListApplicationsHandler(config)))
+	mux.Handle("/api/applications", http.HandlerFunc(handlers.CreateListApplicationsHandlerJson(config)))
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/mux/web.go
+++ b/mux/web.go
@@ -3,17 +3,12 @@ package mux
 import (
 	"github.com/dbcdk/shelob/handlers"
 	"github.com/dbcdk/shelob/util"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"net/http"
 )
 
 func CreateWebMux(config *util.Config) *http.ServeMux {
 	mux := http.NewServeMux()
-
-	mux.Handle("/", http.HandlerFunc(handlers.CreateListApplicationsHandler(config)))
-	mux.Handle("/api/applications", http.HandlerFunc(handlers.CreateListApplicationsHandlerJson(config)))
 	mux.Handle("/status", http.HandlerFunc(handlers.CreateStatusHandler(config)))
-	mux.Handle("/metrics", promhttp.Handler())
 
 	return mux
 }


### PR DESCRIPTION
read on:

- /status is still served on the regular web port, but is only served if there are no applications deployed that matches the input host header
- /api/applications and the html applications view (served on /) is moved the the admin port
- /metrics are now only served on the admin port

the check "routeToSelf" that previously special-cased the host header "localhost" has been removed.