### PR TITLE
ingress: dont die on ingress resources with no rules

### DIFF
--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -170,9 +170,11 @@ func mapIngress(in v1beta12.Ingress) map[string]Ingress {
 
 		//find suitable path target (we only support / for now)
 		var backend *Ingress
-		for _, p := range r.HTTP.Paths {
-			if p.Path == "" || p.Path == "/" {
-				backend = mapBackend(in.Namespace, p.Backend)
+		if r.HTTP != nil {
+			for _, p := range r.HTTP.Paths {
+				if p.Path == "" || p.Path == "/" {
+					backend = mapBackend(in.Namespace, p.Backend)
+				}
 			}
 		}
 


### PR DESCRIPTION
An ingress resource like this:
```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: redirect-ingress
  namespace: user-foo
spec:
  rules:
  - host: foo.bar.baz
```

... currently kills shelob even though it is perfectly legit. Shelob just firmly expects a HTTP-section to be present below `host: ...`.

This fix has been tested on dbc k8s-staging.