### PR TITLE
Plain HTTP Policy

### DIFF
--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -51,12 +51,14 @@ func mergeFrontends(ingresses map[HostMatch]Ingress, services map[PortMatch]Serv
 		if i.Redirect != nil {
 			frontends[n.HostName] = &util.Frontend{
 				Action:          util.BACKEND_ACTION_REDIRECT,
+				PlainHTTPPolicy: util.PLAIN_HTTP_ALLOW,
 				Redirect:        i.Redirect,
 				Backends:        []util.Backend{},
 			}
 		} else {
 			frontends[n.HostName] = &util.Frontend{
 				Action:          util.BACKEND_ACTION_PROXY_RR,
+				PlainHTTPPolicy: util.PLAIN_HTTP_REDIRECT,
 				Redirect:        nil,
 				Backends:        toBackendList(i.Scheme, services[PortMatch{Object: n.Object, Port: i.Port}], endpoints[n.Object]),
 			}

--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -241,10 +241,10 @@ func mapRedirect(in v1beta12.Ingress) (data *util.Redirect) {
 		if err == nil {
 			_code, err := strconv.ParseInt(in.Annotations[REDIRECT_CODE_ANNOTATION], 10, 16)
 			var code uint16
-			if err == nil && (_code == 301 || _code == 302) {
+			if err == nil && (_code == 301 || _code == 302 || _code == 307) {
 				code = uint16(_code)
 			} else {
-				code = 302 // "302 Found" is the default
+				code = 307 // "307 Temporary Redirect" is the default
 			}
 			data = &util.Redirect{
 				Url:  url,

--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	REDIRECT_URL_ANNOTATION  = "shelob.redirect.url"
-	REDIRECT_CODE_ANNOTATION = "shelob.redirect.code"
+	REDIRECT_URL_ANNOTATION      = "shelob.redirect.url"
+	REDIRECT_CODE_ANNOTATION     = "shelob.redirect.code"
+	PLAIN_HTTP_POLICY_ANNOTATION = "shelob.plain.http.policy"
 )
 
 func UpdateFrontends(config *util.Config) (map[string]*util.Frontend, error) {
@@ -51,14 +52,14 @@ func mergeFrontends(ingresses map[HostMatch]Ingress, services map[PortMatch]Serv
 		if i.Redirect != nil {
 			frontends[n.HostName] = &util.Frontend{
 				Action:          util.BACKEND_ACTION_REDIRECT,
-				PlainHTTPPolicy: util.PLAIN_HTTP_ALLOW,
+				PlainHTTPPolicy: i.PlainHTTPPolicy,
 				Redirect:        i.Redirect,
 				Backends:        []util.Backend{},
 			}
 		} else {
 			frontends[n.HostName] = &util.Frontend{
 				Action:          util.BACKEND_ACTION_PROXY_RR,
-				PlainHTTPPolicy: util.PLAIN_HTTP_REDIRECT,
+				PlainHTTPPolicy: i.PlainHTTPPolicy,
 				Redirect:        nil,
 				Backends:        toBackendList(i.Scheme, services[PortMatch{Object: n.Object, Port: i.Port}], endpoints[n.Object]),
 			}
@@ -191,7 +192,7 @@ func mapIngress(in v1beta12.Ingress) map[string]Ingress {
 		if r.HTTP != nil {
 			for _, p := range r.HTTP.Paths {
 				if p.Path == "" || p.Path == "/" {
-					backend = mapBackend(in.Namespace, p.Backend)
+					backend = mapBackend(in, p.Backend)
 				}
 			}
 		}
@@ -203,6 +204,7 @@ func mapIngress(in v1beta12.Ingress) map[string]Ingress {
 				Name:     r.Host,
 				Port:     80,
 				Redirect: redirect,
+				PlainHTTPPolicy: mapPlainHTTPPolicy(in),
 			}
 		} else if r.Host != "" && backend != nil {
 			out[r.Host] = *backend
@@ -215,6 +217,20 @@ func mapIngress(in v1beta12.Ingress) map[string]Ingress {
 	}
 
 	return out
+}
+
+func mapPlainHTTPPolicy(in v1beta12.Ingress) uint16 {
+	_policy := in.Annotations[PLAIN_HTTP_POLICY_ANNOTATION]
+	switch _policy {
+	case "allow":
+		return util.PLAIN_HTTP_ALLOW
+	case "redirect":
+		return util.PLAIN_HTTP_REDIRECT
+	case "reject":
+		return util.PLAIN_HTTP_REJECT
+	default:
+		return util.PLAIN_HTTP_REDIRECT
+	}
 }
 
 func mapRedirect(in v1beta12.Ingress) (data *util.Redirect) {
@@ -239,7 +255,9 @@ func mapRedirect(in v1beta12.Ingress) (data *util.Redirect) {
 	return
 }
 
-func mapBackend(namespace string, backend v1beta12.IngressBackend) *Ingress {
+func mapBackend(in v1beta12.Ingress, backend v1beta12.IngressBackend) *Ingress {
+
+	namespace := in.Namespace
 
 	port := backend.ServicePort.IntValue()
 	if _, err := toPort(port); err != nil {
@@ -254,6 +272,7 @@ func mapBackend(namespace string, backend v1beta12.IngressBackend) *Ingress {
 		Name:   backend.ServiceName,
 		Port:   uint16(port),
 		Scheme: "http",
+		PlainHTTPPolicy: mapPlainHTTPPolicy(in),
 	}
 }
 

--- a/kubernetes/kubernetes_structs.go
+++ b/kubernetes/kubernetes_structs.go
@@ -27,6 +27,7 @@ type Ingress struct {
 	Name     string
 	Port     uint16
 	Redirect *util.Redirect
+	PlainHTTPPolicy uint16
 }
 
 type Service struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -127,6 +127,27 @@ func CreateForwarder() *forward.Forwarder {
 }
 
 func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.Request, forwarder *forward.Forwarder) string {
+
+	// http vs. https
+	if req.TLS != nil {
+		req.Header.Set("X-Forwarded-Proto", "https")
+	} else {
+		switch frontend.PlainHTTPPolicy {
+		case util.PLAIN_HTTP_ALLOW:
+			req.Header.Set("X-Forwarded-Proto", "http")
+		case util.PLAIN_HTTP_REDIRECT:
+			newUrl := util.UrlClone(req)
+			newUrl.Scheme = "https"
+			frontend.Redirect = &util.Redirect{
+				Url:  newUrl,
+				Code: 302,
+			}
+			frontend.Action = util.BACKEND_ACTION_REDIRECT
+		case util.PLAIN_HTTP_REJECT:
+			frontend.Action = util.BACKEND_ACTION_REJECT
+		}
+	}
+
 	switch frontend.Action {
 	case util.BACKEND_ACTION_REDIRECT:
 		http.Redirect(w, req, frontend.Redirect.Url.String(), int(frontend.Redirect.Code))
@@ -138,6 +159,9 @@ func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.R
 			status := http.StatusServiceUnavailable
 			http.Error(w, http.StatusText(status), status)
 		}
+	case util.BACKEND_ACTION_REJECT:
+		status := http.StatusForbidden
+		http.Error(w, http.StatusText(status), status)
 	}
 
 	return actionToPrometheusRequestType(frontend.Action)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -140,7 +140,7 @@ func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.R
 			newUrl.Scheme = "https"
 			frontend.Redirect = &util.Redirect{
 				Url:  newUrl,
-				Code: 302,
+				Code: 307,
 			}
 			frontend.Action = util.BACKEND_ACTION_REDIRECT
 		case util.PLAIN_HTTP_REJECT:

--- a/util/structs.go
+++ b/util/structs.go
@@ -63,10 +63,18 @@ const (
 	BACKEND_ACTION_SERVE_INTERNAL = iota
 	BACKEND_ACTION_PROXY_RR
 	BACKEND_ACTION_REDIRECT
+	BACKEND_ACTION_REJECT
+)
+
+const (
+	PLAIN_HTTP_ALLOW = iota
+	PLAIN_HTTP_REDIRECT
+	PLAIN_HTTP_REJECT
 )
 
 type Frontend struct {
 	Action   uint16
+	PlainHTTPPolicy uint16
 	Redirect *Redirect
 	Backends []Backend
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,6 +1,10 @@
 package util
 
-import "strings"
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
 
 func ReverseStringArray(array []string) []string {
 	for i, j := 0, len(array)-1; i < j; i, j = i+1, j-1 {
@@ -17,4 +21,18 @@ func StripPortFromDomain(domainWithPort string) string {
 	}
 
 	return domainWithPort
+}
+
+func UrlClone(req *http.Request) *url.URL {
+	return &url.URL{
+		Scheme:     req.URL.Scheme,
+		Opaque:     req.URL.Opaque,
+		User:       req.URL.User,
+		Host:       StripPortFromDomain(req.Host),
+		Path:       req.URL.Path,
+		RawPath:    req.URL.RawPath,
+		ForceQuery: req.URL.ForceQuery,
+		RawQuery:  	req.URL.RawQuery,
+		Fragment:   req.URL.Fragment,
+	}
 }


### PR DESCRIPTION
Possible values of the ingress annotation `shelob.plain.http.policy` are:

`allow` : Plain HTTP traffic is allowed and proxied through shelob
`redirect` : Plain HTTP traffic is redirected to https://<original-req-uri> by shelob
`reject` : Plain HTTP traffic is forbidden and shelob will respond 403 if the ingress frontend is accessed via http://

The default value, if the annotation is unset is: `redirect`.
