### PR TITLE
proxy-rr: fix recently introduced bug that effectively disabled backend load balancing

### DIFF
--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 	"github.com/dbcdk/shelob/util"
+	"github.com/vulcand/oxy/forward"
 	"go.uber.org/zap"
 	v13 "k8s.io/api/core/v1"
 	v1beta12 "k8s.io/api/extensions/v1beta1"
@@ -43,10 +44,10 @@ func UpdateFrontends(config *util.Config) (map[string]*util.Frontend, error) {
 		return nil, err
 	}
 
-	return mergeFrontends(ingresses, services, endpoints), nil
+	return mergeFrontends(config.Forwarder, ingresses, services, endpoints), nil
 }
 
-func mergeFrontends(ingresses map[HostMatch]Ingress, services map[PortMatch]Service, endpoints map[Object][]Endpoint) map[string]*util.Frontend {
+func mergeFrontends(forwarder *forward.Forwarder, ingresses map[HostMatch]Ingress, services map[PortMatch]Service, endpoints map[Object][]Endpoint) map[string]*util.Frontend {
 	frontends := make(map[string]*util.Frontend)
 	for n, i := range ingresses {
 		if i.Redirect != nil {
@@ -55,13 +56,16 @@ func mergeFrontends(ingresses map[HostMatch]Ingress, services map[PortMatch]Serv
 				PlainHTTPPolicy: i.PlainHTTPPolicy,
 				Redirect:        i.Redirect,
 				Backends:        []util.Backend{},
+				RR:              nil,
 			}
 		} else {
+			backends := toBackendList(i.Scheme, services[PortMatch{Object: n.Object, Port: i.Port}], endpoints[n.Object])
 			frontends[n.HostName] = &util.Frontend{
 				Action:          util.BACKEND_ACTION_PROXY_RR,
 				PlainHTTPPolicy: i.PlainHTTPPolicy,
 				Redirect:        nil,
-				Backends:        toBackendList(i.Scheme, services[PortMatch{Object: n.Object, Port: i.Port}], endpoints[n.Object]),
+				Backends:        backends,
+				RR:              util.CreateRR(forwarder, backends),
 			}
 		}
 	}

--- a/kubernetes/backends.go
+++ b/kubernetes/backends.go
@@ -204,10 +204,10 @@ func mapIngress(in v1beta12.Ingress) map[string]Ingress {
 		redirect := mapRedirect(in)
 		if r.Host != "" && redirect != nil {
 			out[r.Host] = Ingress{
-				Scheme:   "http",
-				Name:     r.Host,
-				Port:     80,
-				Redirect: redirect,
+				Scheme:          "http",
+				Name:            r.Host,
+				Port:            80,
+				Redirect:        redirect,
 				PlainHTTPPolicy: mapPlainHTTPPolicy(in),
 			}
 		} else if r.Host != "" && backend != nil {
@@ -273,9 +273,9 @@ func mapBackend(in v1beta12.Ingress, backend v1beta12.IngressBackend) *Ingress {
 		return nil
 	}
 	return &Ingress{
-		Name:   backend.ServiceName,
-		Port:   uint16(port),
-		Scheme: "http",
+		Name:            backend.ServiceName,
+		Port:            uint16(port),
+		Scheme:          "http",
 		PlainHTTPPolicy: mapPlainHTTPPolicy(in),
 	}
 }

--- a/util/structs.go
+++ b/util/structs.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vulcand/oxy/forward"
+	"github.com/vulcand/oxy/roundrobin"
 	"k8s.io/client-go/rest"
 	"net/url"
 	"time"
@@ -73,10 +74,11 @@ const (
 )
 
 type Frontend struct {
-	Action   uint16
+	Action          uint16
 	PlainHTTPPolicy uint16
-	Redirect *Redirect
-	Backends []Backend
+	Redirect        *Redirect
+	Backends        []Backend
+	RR              *roundrobin.RoundRobin
 }
 
 type Backend struct {

--- a/util/utils.go
+++ b/util/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 func ReverseStringArray(array []string) []string {
@@ -42,6 +43,7 @@ func UrlClone(req *http.Request) *url.URL {
 
 func CreateRR(forwarder *forward.Forwarder, backends []Backend) *roundrobin.RoundRobin {
 	// randomize the list of backends to try to circumvent slightly biased load towards the beginning of the backend list (at high backend reconcile rates)
+	rand.Seed(time.Now().UnixNano())
 	rand.Shuffle(len(backends), func(i, j int) { backends[i], backends[j] = backends[j], backends[i] })
 
 	rr, _ := roundrobin.New(forwarder)

--- a/util/utils.go
+++ b/util/utils.go
@@ -35,7 +35,7 @@ func UrlClone(req *http.Request) *url.URL {
 		Path:       req.URL.Path,
 		RawPath:    req.URL.RawPath,
 		ForceQuery: req.URL.ForceQuery,
-		RawQuery:  	req.URL.RawQuery,
+		RawQuery:   req.URL.RawQuery,
 		Fragment:   req.URL.Fragment,
 	}
 }


### PR DESCRIPTION
Tested with one replica of shelob on k8s-prod, and round-robin lb seems to be back in working order.