### PR TITLE
Custom error responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dbcdk/shelob
 
-go 1.12
+go 1.13
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/kubernetes/kubernetes_structs.go
+++ b/kubernetes/kubernetes_structs.go
@@ -23,10 +23,10 @@ type Endpoint struct {
 }
 
 type Ingress struct {
-	Scheme   string
-	Name     string
-	Port     uint16
-	Redirect *util.Redirect
+	Scheme          string
+	Name            string
+	Port            uint16
+	Intercept       *util.Intercept
 	PlainHTTPPolicy uint16
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -152,7 +152,11 @@ func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.R
 
 	switch frontend.Action {
 	case util.BACKEND_ACTION_REDIRECT:
-		http.Redirect(w, req, frontend.Intercept.Url.String(), int(frontend.Intercept.Code))
+		url := frontend.Intercept.Url
+		if url.Path == "" {
+			url.Path = req.RequestURI
+		}
+		http.Redirect(w, req, url.String(), int(frontend.Intercept.Code))
 	case util.BACKEND_ACTION_PROXY_RR:
 		rr := frontend.RR
 		if rr != nil && len(rr.Servers()) > 0 {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -137,19 +137,22 @@ func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.R
 		case util.PLAIN_HTTP_REDIRECT:
 			newUrl := util.UrlClone(req)
 			newUrl.Scheme = "https"
-			frontend.Redirect = &util.Redirect{
+			frontend.Intercept = &util.Intercept{
 				Url:  newUrl,
-				Code: 307,
+				Code: http.StatusTemporaryRedirect,
 			}
 			frontend.Action = util.BACKEND_ACTION_REDIRECT
 		case util.PLAIN_HTTP_REJECT:
-			frontend.Action = util.BACKEND_ACTION_REJECT
+			frontend.Action = util.BACKEND_ACTION_RESPOND
+			frontend.Intercept = &util.Intercept{
+				Code: http.StatusForbidden,
+			}
 		}
 	}
 
 	switch frontend.Action {
 	case util.BACKEND_ACTION_REDIRECT:
-		http.Redirect(w, req, frontend.Redirect.Url.String(), int(frontend.Redirect.Code))
+		http.Redirect(w, req, frontend.Intercept.Url.String(), int(frontend.Intercept.Code))
 	case util.BACKEND_ACTION_PROXY_RR:
 		rr := frontend.RR
 		if rr != nil && len(rr.Servers()) > 0 {
@@ -158,9 +161,13 @@ func dispatchRequest(frontend *util.Frontend, w http.ResponseWriter, req *http.R
 			status := http.StatusServiceUnavailable
 			http.Error(w, http.StatusText(status), status)
 		}
-	case util.BACKEND_ACTION_REJECT:
-		status := http.StatusForbidden
-		http.Error(w, http.StatusText(status), status)
+	case util.BACKEND_ACTION_RESPOND:
+		status := int(frontend.Intercept.Code)
+		responseText := frontend.Intercept.ResponseText
+		if responseText == "" {
+			responseText = http.StatusText(status)
+		}
+		http.Error(w, responseText, status)
 	}
 
 	return actionToPrometheusRequestType(frontend.Action)
@@ -172,6 +179,8 @@ func actionToPrometheusRequestType(a uint16) (request_type string) {
 		request_type = "internal"
 	case util.BACKEND_ACTION_REDIRECT:
 		request_type = "redirect"
+	case util.BACKEND_ACTION_RESPOND:
+		request_type = "respond"
 	case util.BACKEND_ACTION_PROXY_RR:
 		request_type = "proxy"
 	}

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? (import <nixpkgs> {}) }:
 let
-  go = pkgs.go_1_12;
+  go = pkgs.go_1_13;
 
   travis-build = pkgs.writeShellScriptBin "travis-build" ''
     set -euo pipefail

--- a/util/structs.go
+++ b/util/structs.go
@@ -64,7 +64,7 @@ const (
 	BACKEND_ACTION_SERVE_INTERNAL = iota
 	BACKEND_ACTION_PROXY_RR
 	BACKEND_ACTION_REDIRECT
-	BACKEND_ACTION_REJECT
+	BACKEND_ACTION_RESPOND
 )
 
 const (
@@ -76,7 +76,7 @@ const (
 type Frontend struct {
 	Action          uint16
 	PlainHTTPPolicy uint16
-	Redirect        *Redirect
+	Intercept       *Intercept
 	Backends        []Backend
 	RR              *roundrobin.RoundRobin
 }
@@ -85,9 +85,11 @@ type Backend struct {
 	Url *url.URL
 }
 
-type Redirect struct {
-	Url  *url.URL
-	Code uint16
+type Intercept struct {
+	Url          *url.URL
+	Code         uint16
+	ResponseText string
+	Action       uint16
 }
 
 type Reload struct {


### PR DESCRIPTION
Implement extension of the redirect feature for adding custom responseCodes and responseTexts as interceptions.

On an ingress resource, you can now provide the new annotations:

- `shelob.response.code` A custom http error code to send to the client (currently limited to either 400, 403, 404, 410 - default: 400)

- `shelob.response.text` A custom string in plain/text format to send to the client. (if not given, the default http status text is give, e.g. "Bad Request" for 400, "Forbidden" for 403, etc.

The new feature can be tested here: https://platform-dist.k8s-stg.dbccloud.dk/

This PR's second commit improves the redirect feature by appending the original RequestURI to the redirect URI if no Path-component is set on the latter.