### PR TITLE
certs: implement loading of certificates and private keys from local fs 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dbcdk/shelob
 go 1.16
 
 require (
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/kavu/go_reuseport v1.5.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,7 @@ github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/localfs/files.go
+++ b/localfs/files.go
@@ -1,0 +1,81 @@
+package localfs
+
+import (
+	"crypto/tls"
+	"io/ioutil"
+	"github.com/dbcdk/shelob/util"
+	"github.com/fsnotify/fsnotify"
+	"go.uber.org/zap"
+	"github.com/dbcdk/shelob/logging"
+)
+
+var log = logging.GetInstance()
+
+func GetCerts(config *util.Config) (map[string]*tls.Certificate, error) {
+	certs := make(map[string]*tls.Certificate)
+		for name, files := range config.CertFilePairMap {
+			pubRaw, err := ioutil.ReadFile(files.PublicKey)
+			if err != nil {
+				return nil, err
+			}
+			privRaw, err := ioutil.ReadFile(files.PrivateKey)
+			if err != nil {
+				return nil, err
+			}
+			cert, err := util.ParseX509(pubRaw, privRaw)
+			if err != nil {
+				return nil, err
+			}
+			certs[name] = cert
+		}
+		return certs, nil
+}
+
+func WatchSecrets(config *util.Config, updateChan chan util.Reload) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					log.Info("Received inotify write event for file",
+						zap.String("file", event.Name),
+					)
+					updateChan <- util.NewReload("inotify-write-event")
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				log.Error("Inotify watch error",
+					zap.String("error", err.Error()),
+				)
+			case stopping := <-config.State.ShutdownChan:
+				if stopping {
+					log.Info("Stopping inotify watch loop")
+					watcher.Close()
+					return
+				}
+			}
+		}
+	}()
+
+	for _, pair := range config.CertFilePairMap {
+		err = watcher.Add(pair.PublicKey)
+		if err != nil {
+			return err
+		}
+		err = watcher.Add(pair.PrivateKey)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/localfs/files.go
+++ b/localfs/files.go
@@ -2,33 +2,33 @@ package localfs
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"github.com/dbcdk/shelob/logging"
 	"github.com/dbcdk/shelob/util"
 	"github.com/fsnotify/fsnotify"
 	"go.uber.org/zap"
-	"github.com/dbcdk/shelob/logging"
+	"io/ioutil"
 )
 
 var log = logging.GetInstance()
 
 func GetCerts(config *util.Config) (map[string]*tls.Certificate, error) {
 	certs := make(map[string]*tls.Certificate)
-		for name, files := range config.CertFilePairMap {
-			pubRaw, err := ioutil.ReadFile(files.PublicKey)
-			if err != nil {
-				return nil, err
-			}
-			privRaw, err := ioutil.ReadFile(files.PrivateKey)
-			if err != nil {
-				return nil, err
-			}
-			cert, err := util.ParseX509(pubRaw, privRaw)
-			if err != nil {
-				return nil, err
-			}
-			certs[name] = cert
+	for name, files := range config.CertFilePairMap {
+		pubRaw, err := ioutil.ReadFile(files.PublicKey)
+		if err != nil {
+			return nil, err
 		}
-		return certs, nil
+		privRaw, err := ioutil.ReadFile(files.PrivateKey)
+		if err != nil {
+			return nil, err
+		}
+		cert, err := util.ParseX509(pubRaw, privRaw)
+		if err != nil {
+			return nil, err
+		}
+		certs[name] = cert
+	}
+	return certs, nil
 }
 
 func WatchSecrets(config *util.Config, updateChan chan util.Reload) error {

--- a/proxy/listeners.go
+++ b/proxy/listeners.go
@@ -74,7 +74,9 @@ func StartTLSProxyServer(config *util.Config, cl certs.CertLookup) {
 					return cert, nil
 				}
 				log.Warn("Unable to find and serve certificate for host",
-					zap.String("host", info.ServerName))
+					zap.String("host", info.ServerName),
+					zap.Strings("available-certs", cl.CertKeys()),
+				)
 				if selfSigned != nil {
 					return selfSigned, nil
 				} else {

--- a/shelob.go
+++ b/shelob.go
@@ -143,7 +143,11 @@ func main() {
 	backendsChan := make(chan util.Reload)
 	certsChan := make(chan util.Reload)
 
-	certHandler := certs.New(&config, certsChan)
+	certHandler, err := certs.New(&config, certsChan)
+	if err != nil {
+		log.Error("Couldn't start certHandler, exitting... err: " + err.Error())
+		os.Exit(1)
+	}
 	certHandler.RegisterValidityMonitoring()
 
 	go proxy.StartProxyServer(&config)

--- a/util/structs.go
+++ b/util/structs.go
@@ -32,6 +32,7 @@ type Config struct {
 	Kubeconfig          *rest.Config
 	DisableWatch        bool
 	IgnoreNamespaces    map[string]bool
+	CertFilePairMap     map[string]KeyPairPaths
 	CertNamespace       string
 	WildcardCertPrefix  string
 }
@@ -95,6 +96,11 @@ type Intercept struct {
 type Reload struct {
 	Time   time.Time
 	Reason string
+}
+
+type KeyPairPaths struct {
+	PublicKey  string
+	PrivateKey string
 }
 
 func NewReload(reason string) Reload {

--- a/util/utils.go
+++ b/util/utils.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"crypto/tls"
 	"github.com/vulcand/oxy/forward"
 	"github.com/vulcand/oxy/roundrobin"
 	"math/rand"
@@ -52,4 +53,9 @@ func CreateRR(forwarder *forward.Forwarder, backends []Backend) *roundrobin.Roun
 	}
 
 	return rr
+}
+
+func ParseX509(cert []byte, key []byte) (*tls.Certificate, error) {
+	out, err := tls.X509KeyPair(cert, key)
+	return &out, err
 }


### PR DESCRIPTION
- leave code in for kubernetes secrets loading, for now

One needs to set `--cert-file-pairs` to a comma-separated string of `<hostName>:<path-to-pubkey>:<path-to-privkey>` and NOT set `--cert-namespace` for localfs loading to take effect.

Shelob will setup inotify watches on all local files and trigger reload on file changes. Also: Reload will be triggered periodically as it is the case with the current kubernetes secrets implementation.