### PR TITLE
Fix two separate issues which was introduced with vault-cert change

### DIFF
--- a/certs/certs.go
+++ b/certs/certs.go
@@ -21,7 +21,6 @@ var log = logging.GetInstance()
 type CertLookup interface {
 	CertKeys() []string
 	Lookup(hostName string) *tls.Certificate
-	RegisterValidityMonitoring()
 }
 
 type CertHandler struct {
@@ -58,6 +57,7 @@ func New(config *util.Config, certUpdateChan chan util.Reload) (CertLookup, erro
 		queue:           make([]util.Reload, 0),
 		reconcileMethod: reconcileMethod,
 	}
+	handler.registerValidityMonitoring()
 	if reconcileMethod != RECONCILE_METHOD_DISABLED {
 		return handler, handler.reconcileCerts(certUpdateChan)
 	} else {
@@ -170,7 +170,7 @@ func (ch *CertHandler) poll(reload func(update util.Reload)) {
 	}
 }
 
-func (ch *CertHandler) RegisterValidityMonitoring() {
+func (ch *CertHandler) registerValidityMonitoring() {
 	ch.certValidity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "shelob_cert_expiry_days",
 		Help: "Number of days until expiry for shelob TLS-certificates",

--- a/shelob.go
+++ b/shelob.go
@@ -148,7 +148,6 @@ func main() {
 		log.Error("Couldn't start certHandler, exitting... err: " + err.Error())
 		os.Exit(1)
 	}
-	certHandler.RegisterValidityMonitoring()
 
 	go proxy.StartProxyServer(&config)
 	go proxy.StartTLSProxyServer(&config, certHandler)


### PR DESCRIPTION
Bugs:

1. nilpointerdereference at startup, due to metrics guage not initialized when trying to reset the counter

2. failed to proceed at startup and init http-listeners, due to hang in "reconcileCerts"

Both bugs introduced in #48. On this branch, there's a separate commit for each fix.

re 1) moved RegisterValidityMonitoring to certhandler.New(). This ensures that the validity monitoring guage is initialized before the metrics endpoint is setup in main, and thus before the guage is actually used. It also has the added benefit of making registerValidityMonitoring a private method to the certs module. There's no real reason for having that function exposed.

re 2) #48 changes `cert.reconcileCerts()` to return an optional error synchronously to the invoker. This was done to address issues where shelob could fail setting up initial cert reconciliation without actually catching the error, see: https://github.com/DBCDK/shelob/pull/48#discussion_r891079320 ... However, later in the certHandler initializer, we keep the thread in an infinite loop waiting for signals on the update channels. Obviously, the signal monitor loop needs to be forked to a separate thread in order to be able to return "no errors" to main, to allow initial setup and start of shelob to proceed. This error was shadowed/hidden by the nilpointer error above, hence not visible at first glance.
